### PR TITLE
Move to disk storage for Verdaccio

### DIFF
--- a/packages/local-npm-registry/README.md
+++ b/packages/local-npm-registry/README.md
@@ -109,7 +109,7 @@ That's it! Your frontend project will now automatically receive updates whenever
 
 This tool uses Verdaccio (a private npm registry) under the hood to simulate publishing packages locally. It maintains a JSON store that tracks package versions and subscriber relationships, ensuring clean workflows and easy cleanup.
 
-> **Note:** Verdaccio is only started for commands that need to publish packages (`publish` and `subscribe`). The `unpublish` and `unsubscribe` commands only modify package.json files and the local store, so they don't require Verdaccio to be running.
+> **Note:** Verdaccio is only started for commands that need to publish packages (`publish` and `subscribe`). The `unpublish` and `unsubscribe` commands only modify package.json files and the local store, so they don't require Verdaccio to be running necessarily.
 
 ### Why Not Use Local File Paths?
 

--- a/packages/local-npm-registry/package.json
+++ b/packages/local-npm-registry/package.json
@@ -2,7 +2,7 @@
   "name": "@aneuhold/local-npm-registry",
   "author": "Anton G. Neuhold Jr.",
   "license": "MIT",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Manages local npm package installations and updates across your machine.",
   "packageManager": "pnpm@10.11.1",
   "type": "module",

--- a/packages/local-npm-registry/src/services/CommandService.ts
+++ b/packages/local-npm-registry/src/services/CommandService.ts
@@ -166,6 +166,9 @@ export class CommandService {
     // Remove package from local store
     await LocalPackageStoreService.removePackage(targetPackageName);
 
+    // Unpublish from Verdaccio
+    await VerdaccioService.unpublishPackage(targetPackageName);
+
     DR.logger.info(
       `Successfully unpublished ${targetPackageName} and reset all subscribers`
     );

--- a/packages/local-npm-registry/src/services/ConfigService.ts
+++ b/packages/local-npm-registry/src/services/ConfigService.ts
@@ -1,8 +1,10 @@
 import { DR, FileSystemService } from '@aneuhold/core-ts-lib';
 import fs from 'fs-extra';
+import path from 'path';
 import { DEFAULT_CONFIG, LocalNpmConfig } from '../types/LocalNpmConfig.js';
 
 const CONFIG_FILE_NAME = '.local-npm-registry.json';
+export const DATA_DIRECTORY_NAME = '.local-npm-registry';
 
 let cachedConfig: LocalNpmConfig | null = null;
 let configFilePath: string | null = null;
@@ -79,5 +81,17 @@ export class ConfigService {
 
     await fs.writeJson(configPath, defaultConfig, { spaces: 2 });
     return configPath;
+  }
+
+  /**
+   * Gets the path to the data directory where local-npm-registry stores its data.
+   * This is typically a subdirectory of the configured data directory.
+   *
+   * @returns The full path to the data directory.
+   */
+  static async getDataDirectoryPath(): Promise<string> {
+    const config = await ConfigService.loadConfig();
+    const baseDirectory = config.dataDirectory || DEFAULT_CONFIG.dataDirectory;
+    return path.join(baseDirectory, DATA_DIRECTORY_NAME);
   }
 }

--- a/packages/local-npm-registry/src/services/LocalPackageStoreService.ts
+++ b/packages/local-npm-registry/src/services/LocalPackageStoreService.ts
@@ -204,9 +204,7 @@ export class LocalPackageStoreService {
    * Gets the store file path from configuration.
    */
   private static async getStoreFilePath(): Promise<string> {
-    const config = await ConfigService.loadConfig();
-    const baseDirectory = config.dataDirectory || process.cwd();
-    const storeDirectory = path.join(baseDirectory, '.local-npm-registry');
+    const storeDirectory = await ConfigService.getDataDirectoryPath();
 
     // Ensure the directory exists
     await fs.ensureDir(storeDirectory);

--- a/packages/local-npm-registry/src/services/MutexService.ts
+++ b/packages/local-npm-registry/src/services/MutexService.ts
@@ -1,6 +1,5 @@
 import { DR } from '@aneuhold/core-ts-lib';
 import fs from 'fs-extra';
-import os from 'os';
 import path from 'path';
 import lockfile from 'proper-lockfile';
 import { ConfigService } from './ConfigService.js';
@@ -158,9 +157,7 @@ export class MutexService {
    * Gets the lock directory path from configuration.
    */
   private static async getLockDir(): Promise<string> {
-    const config = await ConfigService.loadConfig();
-    const baseDirectory = config.dataDirectory || os.homedir();
-    return path.join(baseDirectory, '.local-npm-registry');
+    return await ConfigService.getDataDirectoryPath();
   }
 
   /**

--- a/packages/local-npm-registry/src/services/VerdaccioService.ts
+++ b/packages/local-npm-registry/src/services/VerdaccioService.ts
@@ -56,11 +56,7 @@ export class VerdaccioService {
    * This must be called before any npm publish commands can work.
    */
   static async start(): Promise<void> {
-    // Setup the Verdaccio configuration if not already done
-    if (!this._verdaccioConfig) {
-      const config = await ConfigService.loadConfig();
-      this._verdaccioConfig = await this.createVerdaccioConfig(config);
-    }
+    await this.loadVerdaccioConfig();
 
     if (this.isStarting) {
       DR.logger.info('Verdaccio is already starting...');
@@ -226,6 +222,19 @@ export class VerdaccioService {
   }
 
   /**
+   * Unpublishes a package from the local Verdaccio registry.
+   * This removes the package from the local Verdaccio storage.
+   *
+   * @param packageName - The name of the package to unpublish
+   */
+  static async unpublishPackage(packageName: string): Promise<void> {
+    // Ensure the config is created
+    await this.loadVerdaccioConfig();
+
+    await this.clearPublishedPackagesLocally(packageName);
+  }
+
+  /**
    * Starts Verdaccio using the runServer function.
    * Verdaccio will automatically stop when the process exits.
    *
@@ -332,6 +341,13 @@ export class VerdaccioService {
         `Failed to clear package "${packageName}" locally: ${String(error)}`
       );
       throw error;
+    }
+  }
+
+  private static async loadVerdaccioConfig(): Promise<void> {
+    const config = await ConfigService.loadConfig();
+    if (!this._verdaccioConfig) {
+      this._verdaccioConfig = await this.createVerdaccioConfig(config);
     }
   }
 

--- a/packages/local-npm-registry/src/types/VerdaccioDb.ts
+++ b/packages/local-npm-registry/src/types/VerdaccioDb.ts
@@ -1,0 +1,17 @@
+/**
+ * The filename for the Verdaccio database file.
+ */
+export const VERDACCIO_DB_FILE_NAME = '.verdaccio-db.json';
+
+/**
+ * The type of the Verdaccio database, which is a JSON file
+ * containing a list of package names.
+ * This is used internally by Verdaccio to track the packages available in
+ * the Verdaccio registry.
+ */
+export type VerdaccioDb = {
+  /**
+   * The list of package names available in the Verdaccio registry.
+   */
+  list: string[];
+};

--- a/packages/local-npm-registry/test-utils/TestProjectUtils.ts
+++ b/packages/local-npm-registry/test-utils/TestProjectUtils.ts
@@ -26,11 +26,6 @@ import {
  * ```txt
  * local-npm-registry/
  * └── tmp/                                    (Global temp directory)
- *     ├── .local-npm-registry.json           (Test-specific config file)
- *     ├── .local-package-store.json          (Isolated package store)
- *     ├── verdaccio-storage/                  (Verdaccio package storage)
- *     │   └── [packages published during tests]
- *     ├── verdaccio-self/                     (Verdaccio internal files)
  *     └── {test-instance-uuid}/              (Unique directory per test)
  *         └── [test packages created by individual tests]
  * ```


### PR DESCRIPTION
This was needed to ensure that packages could be re-installed if multiple were subscribed to in the same project. It still wipes them out before each publish.