### PR TITLE
Add robot-instructions package and convert changelog step to Claude

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,71 +1,22 @@
-## Overall Project Guidelines
+# ts-libs
 
-- TypeScript source code with Vitest testing and pnpm package management
-- Avoid code duplication; reuse existing code when possible
-- Reference `../docs/ci.md` for the CI/CD process and `../docs/dev-tooling.md` for development tooling details
-- Make sure to run `pnpm check`, `pnpm test`, and `pnpm lint` before considering a task complete if you are making code changes. Run it within the package that is being modified, or at the monorepo root to check all packages.
-- Keep responses and code concise, focused, and clean.
+## Language
 
-## Code Style
+@../node_modules/@aneuhold/robot-instructions/src/instructions/lang/typescript.md
 
-### Types & Functions
+## Runtime
 
-- Add explicit types when unclear; extract complex object types to separate `type` declarations
-- Use PascalCase for type names; file names should match the primary exported type
-- Prefix generic type parameters with `T` (e.g. `TSubscription`, `TResult`), so they read differently from concrete types
-- Always order types from the highest-level type first, down to the lowest-level type. A type that references another comes before the type it references
-- Use arrow functions and `const`/`let` (never `var`)
-- Use `async`/`await` instead of `.then()`
-- NEVER use `any` type
-- `unknown` is acceptable as a staging type before narrowing with a type guard, runtime schema (e.g. zod), or an explicit cast at system boundaries (`JSON.parse`, file reads, wire responses, library types that are incorrect). Prefer it over `any` when a cast is unavoidable.
-- NEVER use `!` non-null assertion operator. Check for null / undefined properly if it can be null.
-- Do not export a bunch of random functions from a file. Prefer services / classes.
+@../node_modules/@aneuhold/robot-instructions/src/instructions/runtime/node.md
 
-### Documentation & Naming
+## Tooling
 
-- Add JSDoc for all methods, functions, and classes (only include `@param` if they are complicated / non-intuitive. If you do add `@param`, it needs to be added for all params, omit `@returns` always)
-- Add JSDoc for public class properties only if complex
-- Never prefix functions/methods with underscores
+@../node_modules/@aneuhold/robot-instructions/src/instructions/tooling/vitest.md
 
-### Class Structure
+@../node_modules/@aneuhold/robot-instructions/src/instructions/tooling/npm-package.md
 
-- Order methods by visibility: public, protected, private
-- Within same visibility, order doesn't matter
-- Put static methods before instance methods
+## This repo
 
-### Syntax and Best Practices
-
-- NEVER use `['propertyName']` syntax to access properties, always use `.propertyName` unless the property name is dynamic. Even then though, a variable / constant should be used instead of a string literal.
-- Use object destructuring when accessing multiple properties from an object
-- Prefer template literals over string concatenation.
-
-### Organization & Refactoring
-
-- Always prefer to refactor rather than try and "preserve backwards compatibility". We have control over consumers of the packages in this repo for the most part. We can refactor as much as we like.
-- If you need to create something new, try to organize it among the existing items that are similar.
-
-### Enums
-
-- Use PascalCase for enum names and values
-- Use TypeScript `enum` (not `const enum` or `type`)
-
-## File Organization
-
-### Imports
-
-- Use relative imports within package, package references for external packages
-- Use named imports only (never `import * as`)
-- Import at file top (inline only when absolutely necessary)
-
-### Package Structure
-
-- Include `index.ts` at package root exporting all public APIs
-- Exception: CLI tools use `index.ts` for entry point instead of exports
-- Never include `index.ts` elsewhere in package
-
-## Testing
-
-- Test files: `filename.spec.ts` (matching source file name)
-- Never test private methods directly. Also, don't make methods that should be private public just to get around this. If a method isn't used outside it's own class, it should be private.
-- Structure: Root describe as "Unit Tests"/"Integration Tests", nested describes named after tested methods
-- Always prefer to use the built-in Vitest VS Code extension for testing
+- A pnpm monorepo of TypeScript packages, tested with Vitest.
+- Reference `../docs/ci.md` for the CI/CD process and `../docs/dev-tooling.md` for development tooling details.
+- The root describe in a test file is "Unit Tests" or "Integration Tests".
+- Before considering a task complete, run `pnpm check`, `pnpm test`, and `pnpm lint`. Run them within the package being modified, or at the monorepo root to check all packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-Follow the instructions in CLAUDE.md
+Follow the instructions in .claude/CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ Follow this general flow when making updates to any package in the monorepo:
    git commit -m "Your commit message"
    ```
 
-1. **Push your branch** and create a pull request (it helps to do this first for Copilot):
+1. **Push your branch** and create a pull request:
 
    ```bash
    git push
    ```
 
-1. **Generate changelogs** using the Copilot Agent named "Changelog Updater" just tell it:
+1. **Generate changelogs** with the `changelog` skill:
 
    ```
-   start
+   /changelog
    ```
 
-   This will automatically populate the changelog entries for all modified packages. You can do this in a normal chat window or as a background agent.
+   This populates the changelog entries for all modified packages.
 
 1. **Merge the PR** once all checks pass. Updated packages will automatically publish to NPM and JSR registries.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@aneuhold/eslint-config": "^3.0.2",
+    "@aneuhold/robot-instructions": "^0.1.2",
     "@types/node": "^24.13.3",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@aneuhold/eslint-config':
         specifier: ^3.0.2
         version: 3.0.2(@angular/cli@21.0.3(@types/node@24.13.3)(supports-color@5.5.0))(@types/eslint@9.6.1)(eslint@10.8.0(jiti@2.4.2)(supports-color@5.5.0))(prettier@3.9.6)(supports-color@5.5.0)(svelte@5.28.2)(typescript@6.0.3)
+      '@aneuhold/robot-instructions':
+        specifier: ^0.1.2
+        version: 0.1.2
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -418,6 +421,9 @@ packages:
   '@aneuhold/main-scripts@2.10.3':
     resolution: {integrity: sha512-sNqoJtbK2fOxzzUfouxFSVFpPN/Wz0abp54saNaEJ1/ntvWBD/htJFRepNhjS6j9y2LmBb3TCk2RUp9ipYrkKw==}
     hasBin: true
+
+  '@aneuhold/robot-instructions@0.1.2':
+    resolution: {integrity: sha512-eUA5qaSJTPKY9PRKSmYQLL4U2uGb1bLs+VjF5irXGpchyg4R8Ku5LBs401xh/F3bhmEFt9jnCVkqVNpUAojJmA==}
 
   '@angular-devkit/architect@0.2100.3':
     resolution: {integrity: sha512-PcruWF0+IxXOTZd9MN/3y4A5aTfblALzT/+zWym26PtisaBgWQ3tRPQsf/CgT8EdmZl8eUOAWlNBSkbUj/S/lQ==}
@@ -5565,6 +5571,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - typescript
+
+  '@aneuhold/robot-instructions@0.1.2': {}
 
   '@angular-devkit/architect@0.2100.3':
     dependencies:


### PR DESCRIPTION
Replaces the duplicated conventions in `.claude/CLAUDE.md` with references to `@aneuhold/robot-instructions`, and moves the changelog step off Copilot.

## Changes

- Adds `@aneuhold/robot-instructions` as a root dev dependency.
- `.claude/CLAUDE.md` references the shared TypeScript, Node, Vitest, and npm package files instead of restating them, dropping from 75 lines to the repo-specific notes.
- Keeps the docs pointers, the "Unit Tests" / "Integration Tests" root describe convention, and the verification commands.
- `AGENTS.md` points at `.claude/CLAUDE.md` rather than a `CLAUDE.md` that does not exist at the root.
- The readme PR process now uses the `changelog` skill instead of the "Changelog Updater" Copilot agent.

Only root files change, so no package version bumps or changelog entries are needed.
